### PR TITLE
Add reusable JS lint job

### DIFF
--- a/.github/workflows/php-workflow.yml
+++ b/.github/workflows/php-workflow.yml
@@ -109,3 +109,45 @@ jobs:
           SNYK_TOKEN: ${{ secrets.securityToken }}
         with:
           args: --severity-threshold=low --all-projects
+
+  js-lint:
+    name: JavaScript Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for package.json
+        id: has_package
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "package.json"
+
+      - name: Determine lint script availability
+        if: steps.has_package.outputs.files_exists == 'true'
+        id: has_lint_script
+        run: |
+          if jq -e '.scripts["lint:js"]' package.json >/dev/null; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js
+        if: steps.has_lint_script.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm dependencies
+        if: steps.has_lint_script.outputs.enabled == 'true'
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Run JavaScript linting
+        if: steps.has_lint_script.outputs.enabled == 'true'
+        run: npm run lint:js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0 (2025-11-04)
+
+* Adding reusable JavaScript linting job to the PHP workflow
+
 ## 1.2.0 (2025-06-26)
 
 * Switching from using Code Climate to Qlty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0 (2025-11-04)
+## 1.3.0 (2025-11-XX)
 
 * Adding reusable JavaScript linting job to the PHP workflow
 


### PR DESCRIPTION
## Summary
- add reusable JavaScript lint job that skips when package.json or lint script missing
- share Node setup and install logic for repos consuming php workflow

## Testing
- not run (configuration only)


Note to self (Elizabeth): when this gets merged need to delete the v1 tag and make this new commit the new v1 tag.
